### PR TITLE
README should state that you need to have Yarn installed.

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,9 +25,16 @@ node: v18.12.0
 ```bash
 npm install
 # or
-yarn 
+yarn
 ```
-2. Goto Clerk Dashboard and create an application you will get the below mentioned credentials. (Step: 3)  
+
+If you do not have yarn installed locally on your system, you will first need to install it with the following line:
+
+```bash
+npm install -g yarn
+```
+
+2. Goto Clerk Dashboard and create an application you will get the below mentioned credentials. (Step: 3)
 
 3. Create a `.env` file in the root folder.
     Add these env configs...
@@ -37,14 +44,14 @@ yarn
     NEXT_PUBLIC_CLERK_PUBLISHABLE_KEY=`<CLERK PUBLISHABLE KEY>`
     CLERK_SECRET_KEY=`<CLERK SECRET KEY>`
 
-4. Seeder Script (Optional)  
-  To seed  
-  Set `"type":"module"` in `package.json`,  
-  Modify acc. to you needs  
-  RUN!  
+4. Seeder Script (Optional)
+  To seed
+  Set `"type":"module"` in `package.json`,
+  Modify acc. to you needs
+  RUN!
 
     Enjoy
-    
+
 <h2><a id="user-content-about" class="anchor" aria-hidden="true" href="#about"><svg class="octicon octicon-link" viewBox="0 0 16 16" version="1.1" width="16" height="16" aria-hidden="true"><path fill-rule="evenodd" d="M7.775 3.275a.75.75 0 001.06 1.06l1.25-1.25a2 2 0 112.83 2.83l-2.5 2.5a2 2 0 01-2.83 0 .75.75 0 00-1.06 1.06 3.5 3.5 0 004.95 0l2.5-2.5a3.5 3.5 0 00-4.95-4.95l-1.25 1.25zm-4.69 9.64a2 2 0 010-2.83l2.5-2.5a2 2 0 012.83 0 .75.75 0 001.06-1.06 3.5 3.5 0 00-4.95 0l-2.5 2.5a3.5 3.5 0 004.95 4.95l1.25-1.25a.75.75 0 00-1.06-1.06l-1.25 1.25a2 2 0 01-2.83 0z"></path></svg></a>Support</h2>
 
 <a href="https://www.buymeacoffee.com/vishwajeetraj11" target="_blank"><img src="https://cdn.buymeacoffee.com/buttons/default-orange.png" alt="Buy Me A Coffee" height="41" width="174"></a>


### PR DESCRIPTION
Currently, the two options for installing dependencies are to either use `npm install` or `yarn`. However `npm install` doesn't work and I've submitted an issue detailing the problem. Currently only `yarn` can work, so there should be an indication for first-time users that they will need to have yarn locally install.

If not, there should be an additional setup step to install yarn with `npm install -g yarn`.